### PR TITLE
Load project-local .bant macro file for custom rule expansion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,30 @@ If you suspect an operation is not evaluated, invoke bant with extra verbose
 `-vv` - it will show what operations it glossed over (If observed in the field:
 good candidate to implement next).
 
+#### Macros
+
+Bant ships with a set of [built-in macros][builtin-macros] that map common
+custom rules (e.g. `cc_proto_library`) to standard Bazel rules so that `dwyu`
+and other commands can analyze them.
+
+If your project uses custom rules that bant doesn't know about (e.g.
+`my_cc_test` wrapping `cc_test`), you can define project-local macros in a
+`.bant-macros` file at the project root. The syntax is the same as the
+built-in macros file:
+
+```
+# .bant-macros
+my_cc_test = bant_forward_args(cc_test())
+my_cc_library = bant_forward_args(cc_library())
+```
+
+`bant_forward_args(target_rule())` expands calls to the custom rule by
+forwarding all arguments to the specified standard rule.
+
+Project-local macros are loaded in addition to the built-in macros. If a
+project-local macro has the same name as a built-in, the project-local
+definition takes precedence.
+
 #### Grep
 As targets to print, the usual bazel patterns apply, such as exact label names,
 `...`, or `:all`; also, some `*`-globbing label names is supported in the

--- a/bant/BUILD
+++ b/bant/BUILD
@@ -57,6 +57,7 @@ cc_binary(
         "//bant/util:stat",
         "//bant/util:table-printer",
         "@abseil-cpp//absl/container:flat_hash_set",
+        "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/time",
     ],

--- a/bant/cli-commands.cc
+++ b/bant/cli-commands.cc
@@ -26,6 +26,7 @@
 #include <string_view>
 #include <vector>
 
+#include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "bant/explore/aliased-by.h"
 #include "bant/explore/dependency-graph.h"
@@ -182,6 +183,13 @@ CliStatus RunCommand(Session &session, Command cmd,
   CommandlineFlags flags = session.flags();
 
   bant::ParsedProject project(workspace, flags.verbose);
+  {
+    const FilesystemPath macro_file(".bant");
+    if (auto status = project.LoadMacrosFromFile(session, macro_file);
+        !status.ok() && !absl::IsNotFound(status)) {
+      session.info() << "Warning: " << status.message() << "\n";
+    }
+  }
   if (NeedsProjectPopulated(cmd, patterns)) {
     Stat &stats = session.GetStatsFor("Initial load from pattern", "packages");
     const ScopedTimer timer(&stats.duration);

--- a/bant/cli-commands.cc
+++ b/bant/cli-commands.cc
@@ -184,7 +184,7 @@ CliStatus RunCommand(Session &session, Command cmd,
 
   bant::ParsedProject project(workspace, flags.verbose);
   {
-    const FilesystemPath macro_file(".bant");
+    const FilesystemPath macro_file(".bant-macros");
     if (auto status = project.LoadMacrosFromFile(session, macro_file);
         !status.ok() && !absl::IsNotFound(status)) {
       session.info() << "Warning: " << status.message() << "\n";

--- a/bant/frontend/BUILD
+++ b/bant/frontend/BUILD
@@ -127,6 +127,7 @@ cc_library(
         "@abseil-cpp//absl/container:flat_hash_map",
         "@abseil-cpp//absl/log:check",
         "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/strings",
     ],
 )
 

--- a/bant/frontend/macro-substitutor_test.cc
+++ b/bant/frontend/macro-substitutor_test.cc
@@ -176,13 +176,14 @@ another_rule(
 }
 
 TEST_F(MacroSubstituteTest, ProjectLocalMacroForwardArgs) {
-  // Simulate a project-local macro like xla_test = bant_forward_args(cc_test())
+  // Simulate a project-local macro like my_cc_test =
+  // bant_forward_args(cc_test())
   SetMacroContent(R"(
-xla_test = bant_forward_args(cc_test())
+my_cc_test = bant_forward_args(cc_test())
 )");
 
   const auto result = MacroSubstituteAndPrint(R"input(
-xla_test(
+my_cc_test(
    name = "my_test",
    deps = ["//some:lib"],
 )

--- a/bant/frontend/macro-substitutor_test.cc
+++ b/bant/frontend/macro-substitutor_test.cc
@@ -175,4 +175,88 @@ another_rule(
   EXPECT_EQ(result.first, result.second);
 }
 
+TEST_F(MacroSubstituteTest, ProjectLocalMacroForwardArgs) {
+  // Simulate a project-local macro like xla_test = bant_forward_args(cc_test())
+  SetMacroContent(R"(
+xla_test = bant_forward_args(cc_test())
+)");
+
+  const auto result = MacroSubstituteAndPrint(R"input(
+xla_test(
+   name = "my_test",
+   deps = ["//some:lib"],
+)
+)input",
+                                              R"expanded(
+cc_test(
+    name = "my_test",
+    deps = ["//some:lib"],
+)
+)expanded");
+
+  EXPECT_EQ(result.first, result.second);
+}
+
+TEST_F(MacroSubstituteTest, MultipleSetMacroContentCallsAreAdditive) {
+  // First call: define one macro
+  SetMacroContent(R"(
+first_rule = bant_forward_args(cc_library())
+)");
+
+  // Second call: define another macro (should not crash, should be additive)
+  SetMacroContent(R"(
+second_rule = bant_forward_args(cc_test())
+)");
+
+  // Both macros should work
+  const auto result1 = MacroSubstituteAndPrint(R"input(
+first_rule(
+   name = "lib1",
+)
+)input",
+                                               R"expanded(
+cc_library(
+    name = "lib1",
+)
+)expanded");
+  EXPECT_EQ(result1.first, result1.second);
+
+  const auto result2 = MacroSubstituteAndPrint(R"input(
+second_rule(
+   name = "test1",
+)
+)input",
+                                               R"expanded(
+cc_test(
+    name = "test1",
+)
+)expanded");
+  EXPECT_EQ(result2.first, result2.second);
+}
+
+TEST_F(MacroSubstituteTest, ProjectLocalMacroOverridesBuiltin) {
+  // First call: define a macro
+  SetMacroContent(R"(
+my_rule = bant_forward_args(cc_library())
+)");
+
+  // Second call: override same macro name
+  SetMacroContent(R"(
+my_rule = bant_forward_args(cc_test())
+)");
+
+  // Should use the latest definition (cc_test, not cc_library)
+  const auto result = MacroSubstituteAndPrint(R"input(
+my_rule(
+   name = "foo",
+)
+)input",
+                                              R"expanded(
+cc_test(
+    name = "foo",
+)
+)expanded");
+  EXPECT_EQ(result.first, result.second);
+}
+
 }  // namespace bant

--- a/bant/frontend/parsed-project.cc
+++ b/bant/frontend/parsed-project.cc
@@ -457,15 +457,15 @@ Node *ParsedProject::FindMacro(std::string_view name) const {
 }
 
 absl::Status ParsedProject::AddMacroContent(std::string_view source_name,
-                                              std::string_view content,
-                                              std::ostream &errors) {
+                                            std::string_view content,
+                                            std::ostream &errors) {
   auto named_content =
     std::make_unique<NamedLineIndexedContent>(source_name, content);
   Scanner scanner(*named_content);
   Parser parser(&scanner, &arena_, errors);
   List *const macro_list = parser.parse();
   if (parser.parse_error()) {
-    return absl::InternalError(
+    return absl::InvalidArgumentError(
       absl::StrCat("Parse error in macro file ", source_name));
   }
   for (Node *n : *macro_list) {
@@ -492,7 +492,7 @@ absl::Status ParsedProject::LoadMacrosFromFile(
       absl::StrCat("Macro file not found: ", macro_file.path()));
   }
   auto owned = std::make_unique<std::string>(std::move(*content));
-  std::string_view view = *owned;
+  const std::string_view view = *owned;
   macro_owned_content_.push_back(std::move(owned));
   std::stringstream error_collect;
   absl::Status status = AddMacroContent(macro_file.path(), view, error_collect);

--- a/bant/frontend/parsed-project.cc
+++ b/bant/frontend/parsed-project.cc
@@ -470,9 +470,16 @@ absl::Status ParsedProject::AddMacroContent(std::string_view source_name,
   }
   for (Node *n : *macro_list) {
     Assignment *const macro_assignment = n->CastAsAssignment();
-    CHECK(macro_assignment) << "Expected assignment, got " << n;
+    if (!macro_assignment) {
+      return absl::InvalidArgumentError(
+        absl::StrCat(source_name, ": Expected assignment, got ", ToString(n)));
+    }
     Identifier *const name = macro_assignment->lhs_maybe_identifier();
-    CHECK(name) << "Not an identifier on lhs of " << macro_assignment;
+    if (!name) {
+      return absl::InvalidArgumentError(
+        absl::StrCat(source_name, ": Expected identifier on lhs of ",
+                     ToString(macro_assignment)));
+    }
     macros_.insert_or_assign(name->id(), macro_assignment->value());
   }
   RegisterLocationRange(named_content->content(), named_content.get());

--- a/bant/frontend/parsed-project.cc
+++ b/bant/frontend/parsed-project.cc
@@ -32,6 +32,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/check.h"
 #include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
 #include "bant/builtin-macros.h"
 #include "bant/explore/query-utils.h"
 #include "bant/frontend/ast.h"
@@ -455,28 +456,49 @@ Node *ParsedProject::FindMacro(std::string_view name) const {
   return nullptr;
 }
 
-absl::Status ParsedProject::SetBuiltinMacroContent(std::string_view content) {
-  if (macro_content_) {
-    // In tests, call ParsedProject without builtin-macros
-    return absl::InternalError("Attempt to register multiple built-ins");
-  }
-  macro_content_ =
-    std::make_unique<NamedLineIndexedContent>("(bant-builtin)", content);
-  Scanner scanner(*macro_content_);  // directly parsing compiled-in string-view
-  Parser parser(&scanner, &arena_, std::cerr);
-  List *const builtin_list = parser.parse();
+absl::Status ParsedProject::AddMacroContent(std::string_view source_name,
+                                              std::string_view content,
+                                              std::ostream &errors) {
+  auto named_content =
+    std::make_unique<NamedLineIndexedContent>(source_name, content);
+  Scanner scanner(*named_content);
+  Parser parser(&scanner, &arena_, errors);
+  List *const macro_list = parser.parse();
   if (parser.parse_error()) {
-    return absl::InternalError("Issue in bant/builtin-macros.bnt");
+    return absl::InternalError(
+      absl::StrCat("Parse error in macro file ", source_name));
   }
-  for (Node *n : *builtin_list) {
+  for (Node *n : *macro_list) {
     Assignment *const macro_assignment = n->CastAsAssignment();
     CHECK(macro_assignment) << "Expected assignment, got " << n;
     Identifier *const name = macro_assignment->lhs_maybe_identifier();
     CHECK(name) << "Not an identifier on lhs of " << macro_assignment;
-    CHECK(macros_.emplace(name->id(), macro_assignment->value()).second)
-      << "Multiple macros of name " << name->id();
+    macros_.insert_or_assign(name->id(), macro_assignment->value());
   }
-  RegisterLocationRange(macro_content_->content(), macro_content_.get());
+  RegisterLocationRange(named_content->content(), named_content.get());
+  macro_contents_.push_back(std::move(named_content));
   return absl::OkStatus();
+}
+
+absl::Status ParsedProject::SetBuiltinMacroContent(std::string_view content) {
+  return AddMacroContent("(bant-builtin)", content, std::cerr);
+}
+
+absl::Status ParsedProject::LoadMacrosFromFile(
+  Session &session, const FilesystemPath &macro_file) {
+  std::optional<std::string> content = ReadFileToString(macro_file);
+  if (!content.has_value()) {
+    return absl::NotFoundError(
+      absl::StrCat("Macro file not found: ", macro_file.path()));
+  }
+  auto owned = std::make_unique<std::string>(std::move(*content));
+  std::string_view view = *owned;
+  macro_owned_content_.push_back(std::move(owned));
+  std::stringstream error_collect;
+  absl::Status status = AddMacroContent(macro_file.path(), view, error_collect);
+  if (!status.ok()) {
+    session.info() << error_collect.str();
+  }
+  return status;
 }
 }  // namespace bant

--- a/bant/frontend/parsed-project.h
+++ b/bant/frontend/parsed-project.h
@@ -127,7 +127,7 @@ class ParsedProject : public SourceLocator {
   void RegisterLocationRange(std::string_view range,
                              const SourceLocator *source_locator);
 
-  // Load project-local macro definitions from a .bant file.
+  // Load project-local macro definitions from a .bant-macros file.
   // Returns NotFoundError if the file doesn't exist (caller can ignore).
   absl::Status LoadMacrosFromFile(Session &session,
                                   const FilesystemPath &macro_file);
@@ -163,8 +163,7 @@ class ParsedProject : public SourceLocator {
   // Core macro-parsing logic: parse assignments from content and add to
   // macros_ map. On name collision, later definitions win.
   absl::Status AddMacroContent(std::string_view source_name,
-                                std::string_view content,
-                                std::ostream &errors);
+                               std::string_view content, std::ostream &errors);
 
   Arena arena_{1 << 20};
   const BazelWorkspace workspace_;

--- a/bant/frontend/parsed-project.h
+++ b/bant/frontend/parsed-project.h
@@ -21,9 +21,11 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <ostream>
 #include <string>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/status/status.h"
@@ -125,6 +127,11 @@ class ParsedProject : public SourceLocator {
   void RegisterLocationRange(std::string_view range,
                              const SourceLocator *source_locator);
 
+  // Load project-local macro definitions from a .bant file.
+  // Returns NotFoundError if the file doesn't exist (caller can ignore).
+  absl::Status LoadMacrosFromFile(Session &session,
+                                  const FilesystemPath &macro_file);
+
   // Find content of a macro with given name or nullptr if no such macro
   // exists. The returned node and any of its nodes must not be altered.
   // (So VariableSubstituteCopy(), careful if it ends up in Elaboration with
@@ -148,15 +155,21 @@ class ParsedProject : public SourceLocator {
                                 const FilesystemPath &build_file,
                                 const BazelPackage &package);
 
-  // Set content of bant file defining the maccros to be found in FindMacro().
-  // Typically, this will only happen once with the built-in macros, but
-  // can be called in tests to set a specific test content.
+  // Set content of bant file defining the macros to be found in FindMacro().
+  // Can be called multiple times (e.g. built-in + project-local).
   // Passed string view must outlive ParsedProject lifetime.
   absl::Status SetBuiltinMacroContent(std::string_view content);
 
+  // Core macro-parsing logic: parse assignments from content and add to
+  // macros_ map. On name collision, later definitions win.
+  absl::Status AddMacroContent(std::string_view source_name,
+                                std::string_view content,
+                                std::ostream &errors);
+
   Arena arena_{1 << 20};
   const BazelWorkspace workspace_;
-  std::unique_ptr<NamedLineIndexedContent> macro_content_;
+  std::vector<std::unique_ptr<NamedLineIndexedContent>> macro_contents_;
+  std::vector<std::unique_ptr<std::string>> macro_owned_content_;
   int error_count_ = 0;
   Package2Parsed package_to_parsed_;  // BUILD files.
   Target2Parsed starlark_to_parsed_;  // Starlark files.

--- a/bant/tool/dwyu.cc
+++ b/bant/tool/dwyu.cc
@@ -713,6 +713,12 @@ size_t CreateDependencyEdits(Session &session, const ParsedProject &project,
   DWYUGenerator gen(session, project, edit_counting_forwarder);
   const size_t target_count = gen.CreateEditsForPattern(pattern);
   session.info() << "Checked DWYU on " << target_count << " targets.";
+  if (target_count == 0 && pattern.HasFilter()) {
+    session.info()
+      << "\nNote: No cc_library/cc_binary/cc_test targets matched the"
+         " pattern. Target might not exist or uses an unknown custom rule."
+         "\nConsider adding a macro to your project's .bant file.";
+  }
   if (edits_emitted) {
     session.info() << " Emitted " << edits_emitted << " edits.";
   }

--- a/bant/tool/dwyu.cc
+++ b/bant/tool/dwyu.cc
@@ -717,7 +717,7 @@ size_t CreateDependencyEdits(Session &session, const ParsedProject &project,
     session.info()
       << "\nNote: No cc_library/cc_binary/cc_test targets matched the"
          " pattern. Target might not exist or uses an unknown custom rule."
-         "\nConsider adding a macro to your project's .bant file.";
+         "\nConsider adding a macro to your project's .bant-macros file.";
   }
   if (edits_emitted) {
     session.info() << " Emitted " << edits_emitted << " edits.";


### PR DESCRIPTION
Projects like XLA (https://github.com/openxla/xla) use custom macros (e.g. xla_test()) that wrap standard Bazel rules (cc_test). Without understanding these macros, `bant dwyu` can't analyze targets defined with them.

This change:
- Refactors macro loading to support multiple sources (built-in + project-local) via AddMacroContent(), with later definitions winning on name collision.
- Loads a `.bant` file from the project root at startup, allowing projects to define macro expansions (e.g. xla_test = bant_forward_args(cc_test())).
- Adds a helpful hint when DWYU matches zero targets, suggesting the user add a .bant macro file.
- Adds tests for project-local macro loading, additive macro registration, and override semantics.