### PR TITLE
Fix subscript/dot precedence and unary minus evaluation

### DIFF
--- a/bant/builtin-macros.bnt
+++ b/bant/builtin-macros.bnt
@@ -159,10 +159,10 @@ xls_ir_cc_library = (
 xls_dslx_verilog = genrule(
     name = name,
     outs = [
-        (verilog_file.rsplit(".", 1))[0] + ".block.ir",
-        (verilog_file.rsplit(".", 1))[0] + ".codegen_options.textproto",
-        (verilog_file.rsplit(".", 1))[0] + ".schedule_options.textproto",
-        (verilog_file.rsplit(".", 1))[0] + ".sig.textproto",
+        verilog_file.rsplit(".", 1)[0] + ".block.ir",
+        verilog_file.rsplit(".", 1)[0] + ".codegen_options.textproto",
+        verilog_file.rsplit(".", 1)[0] + ".schedule_options.textproto",
+        verilog_file.rsplit(".", 1)[0] + ".sig.textproto",
         verilog_file,
     ],
 )
@@ -170,10 +170,10 @@ xls_dslx_verilog = genrule(
 xls_ir_verilog = genrule(
     name = name,
     outs = [
-        (verilog_file.rsplit(".", 1))[0] + ".block.ir",
-        (verilog_file.rsplit(".", 1))[0] + ".codegen_options.textproto",
-        (verilog_file.rsplit(".", 1))[0] + ".schedule_options.textproto",
-        (verilog_file.rsplit(".", 1))[0] + ".sig.textproto",
+        verilog_file.rsplit(".", 1)[0] + ".block.ir",
+        verilog_file.rsplit(".", 1)[0] + ".codegen_options.textproto",
+        verilog_file.rsplit(".", 1)[0] + ".schedule_options.textproto",
+        verilog_file.rsplit(".", 1)[0] + ".sig.textproto",
         verilog_file,
     ],
 )

--- a/bant/frontend/elaboration.cc
+++ b/bant/frontend/elaboration.cc
@@ -385,6 +385,7 @@ class SimpleElaborator : public BaseNodeReplacementVisitor {
   }
 
   Node *VisitUnaryExpr(UnaryExpr *unary) final {
+    BaseNodeReplacementVisitor::VisitUnaryExpr(unary);
     Scalar *scalar = unary->node()->CastAsScalar();
     if (!scalar) return unary;
     if (scalar->type() != Scalar::ScalarType::kInt) return unary;

--- a/bant/frontend/elaboration_test.cc
+++ b/bant/frontend/elaboration_test.cc
@@ -514,7 +514,7 @@ A = "some-filename.foo.bar.txt".rsplit(".")
 A1 = "some-filename.foo.bar.txt".rsplit(".", -1)  # equivalent to split all
 B = "some-filename.foo.bar.txt".rsplit(".", 1)
 C = "some-filename".rsplit(".", 1)
-D = ("remove-suffix.txt".rsplit(".", 1))[0]  # precedence: should not need ()
+D = "remove-suffix.txt".rsplit(".", 1)[0]
 E = "Hello the fillword the remove".rsplit(" the ")
 )",
     R"(
@@ -539,16 +539,15 @@ A1 = "some-filename.foo.bar.txt".split(".", -1)
 A2 = "some-filename.foo.bar.txt".split(".")[1]
 B = "some-filename.foo.bar.txt".split(".", 1)
 C = "some-filename".split(".", 1)
-D = ("get-prefix.tar.gz".split("."))[0]  # TODO: precedence: should not need ()
+D = "get-prefix.tar.gz".split(".")[0]
 E = "Hello the fillword the remove".split(" the ")
-F = ("1.2.3.bcr.1".split(".bcr.", 1))[0] # TODO: precedence: should not need ()
+F = "1.2.3.bcr.1".split(".bcr.", 1)[0]
 )",
     R"(
 S = ["some", "space", "separated"]
 A = ["some-filename", "foo", "bar", "txt"]
 A1 = ["some-filename", "foo", "bar", "txt"]
-#A2 = "foo"                                     # did not evaluate...
-A2 = "some-filename.foo.bar.txt".split(".")[1]  # ... because wrong precedence
+A2 = "foo"
 B = ["some-filename", "foo.bar.txt"]
 C = ["some-filename"]
 D = "get-prefix"
@@ -601,7 +600,7 @@ TEST_F(ElaborationTest, LenFunction) {
 FOO = len("hello")
 BAR = len(variable)
 BAZ = len(["a", "b", "c"])
-EXAMPLE = "somefilename.txt"[:0-len(".txt")]  # TODO not unary: precedence issue
+EXAMPLE = "somefilename.txt"[:-len(".txt")]
 )",
     R"(
 FOO = 5
@@ -921,6 +920,54 @@ TEST_F(ElaborationTest, GlobDirKnownPrefixInSubpackage) {
   auto result =
     TestGlobFile("GlobDirKnownPrefixInSubpackage", this, "some/pkg",  //
                  "abc/foo.xyz", "abc/*.xyz");
+  EXPECT_EQ(result.first, result.second);
+}
+
+TEST_F(ElaborationTest, ArithPrecedence) {
+  auto result = ElabAndPrint(
+    R"(
+QIX = 9 * 9 + 1  # multiply before add
+QUX = 1 + 9 * 9  # multiply before add
+FIX = 9 * (9 + 1)
+FUX = (1 + 9) * 9
+)",
+    R"(
+QIX = 82
+QUX = 82
+FIX = 90
+FUX = 90
+)");
+
+  EXPECT_EQ(result.first, result.second);
+}
+
+TEST_F(ElaborationTest, MethodCallSubscriptPrecedence) {
+  auto result = ElabAndPrint(
+    R"(
+A = "some-filename.foo.bar.txt".split(".")[1]
+B = "get-prefix.tar.gz".split(".")[0]
+C = "1.2.3.bcr.1".split(".bcr.", 1)[0]
+D = "remove-suffix.txt".rsplit(".", 1)[0]
+)",
+    R"(
+A = "foo"
+B = "get-prefix"
+C = "1.2.3"
+D = "remove-suffix"
+)");
+
+  EXPECT_EQ(result.first, result.second);
+}
+
+TEST_F(ElaborationTest, SliceExprPrecedence) {
+  auto result = ElabAndPrint(
+    R"(
+EXAMPLE = "somefilename.txt"[:-len(".txt")]
+)",
+    R"(
+EXAMPLE = "somefilename"
+)");
+
   EXPECT_EQ(result.first, result.second);
 }
 

--- a/bant/frontend/parser.cc
+++ b/bant/frontend/parser.cc
@@ -363,20 +363,12 @@ class Parser::Impl {
     default: n = ParseValueOrIdentifier(can_be_optional);
     }
 
-    // Check for array access. Strong binding
-    Token upcoming = scanner_->Peek();
+    // Check for ternary if-else.
+    const Token upcoming = scanner_->Peek();
     if (upcoming.type == TokenType::kIf) {
       return ParseIfElse(n);  // TODO: figure out what precendence level this is
     }
 
-    for (/**/; upcoming.type == '['; upcoming = scanner_->Peek()) {
-      if (upcoming.newline_since_last_token) {  // new toplevel construct
-        return n;
-      }
-      const Token op = scanner_->Next();  // '[' operation.
-      n = Make<BinOpNode>(n, ParseArrayOrSliceAccess(), op.type, op.text);
-      // Suffix expression, maybe there is more.
-    }
     return n;
   }
 
@@ -389,10 +381,20 @@ class Parser::Impl {
     if (n == nullptr) return n;
     for (;;) {
       const Token upcoming = scanner_->Peek();
-      if (!IsTokenIn(upcoming.type, kPrecedenceList[prec])) break;
-      const Token op = scanner_->Next();
-      Node *const right = ParseWithPrecedence(prec - 1);
-      n = Make<BinOpNode>(n, right, op.type, op.text);
+      if (IsTokenIn(upcoming.type, kPrecedenceList[prec])) {
+        const Token op = scanner_->Next();
+        Node *const right = ParseWithPrecedence(prec - 1);
+        n = Make<BinOpNode>(n, right, op.type, op.text);
+        continue;
+      }
+      // Array/slice subscript [] binds at the same level as dot (.).
+      if (prec == 1 && upcoming.type == '[' &&
+          !upcoming.newline_since_last_token) {
+        const Token op = scanner_->Next();
+        n = Make<BinOpNode>(n, ParseArrayOrSliceAccess(), op.type, op.text);
+        continue;
+      }
+      break;
     }
     return n;
   }

--- a/bant/frontend/parser_test.cc
+++ b/bant/frontend/parser_test.cc
@@ -474,6 +474,37 @@ TEST_F(ParserTest, ParseListComprehension) {
 )")));
 }
 
+// Subscript [] binds at the same precedence as dot, left-to-right.
+// This ensures "str".method()[0] parses as (("str".method())[0]) not
+// ("str".(method()[0])).
+TEST_F(ParserTest, SubscriptAfterMethodCall) {
+  Node *const expected = List({
+    // "str".split(".")[0] → SUBSCRIPT(DOT("str", split(".")), 0)
+    Assign("a", Op('[', Op('.', Str("str"), Call("split", Tuple({Str(".")}))),
+                   Int(0))),
+    // x.y[0] → SUBSCRIPT(DOT(x, y), 0)
+    Assign("b", Op('[', Op('.', Id("x"), Id("y")), Int(0))),
+    // x[0].y → DOT(SUBSCRIPT(x, 0), y)
+    Assign("c", Op('.', Op('[', Id("x"), Int(0)), Id("y"))),
+    // x.y[0].z → DOT(SUBSCRIPT(DOT(x, y), 0), z)
+    Assign("d", Op('.', Op('[', Op('.', Id("x"), Id("y")), Int(0)), Id("z"))),
+    // a.b()[1][2] → SUBSCRIPT(SUBSCRIPT(DOT(a, b()), 1), 2)
+    Assign("e", Op('[', Op('[', Op('.', Id("a"), Call("b", Tuple({}))), Int(1)),
+                   Int(2))),
+    // [1, 2, 3][0] → SUBSCRIPT([1,2,3], 0)
+    Assign("f", Op('[', List({Int(1), Int(2), Int(3)}), Int(0))),
+  });
+
+  EXPECT_EQ(Print(expected), Print(Parse(R"(
+a = "str".split(".")[0]
+b = x.y[0]
+c = x[0].y
+d = x.y[0].z
+e = a.b()[1][2]
+f = [1, 2, 3][0]
+)")));
+}
+
 // Make sure we don't accidentally see an opening bracket on the next line
 // as array access in the previous one.
 TEST_F(ParserTest, ListComprehensionAfterExpressionIsNotAnArrayAccess) {


### PR DESCRIPTION
## Summary

Fixes two precedence bugs in the parser and elaboration:

1. **Method call + subscript**: `"str".split(".")[0]` was parsed incorrectly because `[]` subscript was handled in `ParseAtom()`, causing it to bind inside the dot's right-hand side instead of outside. Moved `[]` handling to `ParseWithPrecedence()` at the same level as `.` (prec 1) so subscript and dot associate left-to-right.

2. **Unary minus in expressions**: `-len(".txt")` failed to evaluate because `VisitUnaryExpr` checked `CastAsScalar()` without first evaluating children. Added `BaseNodeReplacementVisitor::VisitUnaryExpr(unary)` call so child nodes (e.g. `len()`) are evaluated before the unary check.

### Changes
- **parser.cc**: Remove `[]` loop from `ParseAtom()`, add `[]` handling in `ParseWithPrecedence()` at prec level 1
- **elaboration.cc**: Call base visitor in `VisitUnaryExpr` before `CastAsScalar()`
- **parser_test.cc**: Add `SubscriptAfterMethodCall` test (6 cases covering dot+subscript interleaving)
- **elaboration_test.cc**: Update `SplitStrings` expected value for `A2` (now evaluates correctly), add `ArithPrecedence`, `MethodCallSubscriptPrecedence`, and `SliceExprPrecedence` tests

## Test plan
- [x] `bazel test //bant/frontend:parser_test //bant/frontend:elaboration_test` -- all pass
- [x] `clang-format` -- no formatting changes
- [x] `clang-tidy` -- no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
