### PR TITLE
Add proto_library DWYU support

### DIFF
--- a/bant/explore/header-providers.cc
+++ b/bant/explore/header-providers.cc
@@ -339,6 +339,39 @@ ProvidedFromTargetSet ExtractExpandedHeaderToLibMapping(
   return result;
 }
 
+ProvidedFromTargetSet ExtractProtoToProtoLibMapping(
+  const ParsedProject &project, std::ostream &info_out, bool suffix_index) {
+  ProvidedFromTargetSet result;
+
+  const auto aliased_by_index = ExtractAliasedBy(project);
+
+  for (const auto &[_, build_file] : project.ParsedFiles()) {
+    if (!build_file->ast) continue;
+
+    query::FindTargets(
+      build_file->ast, {"proto_library"}, [&](const query::Result &proto_lib) {
+        auto target = build_file->package.QualifiedTarget(proto_lib.name);
+        if (!target.has_value()) return;
+
+        const auto proto_srcs = query::ExtractStringList(proto_lib.srcs_list);
+        for (std::string_view proto : proto_srcs) {
+          if (!proto.ends_with(".proto")) continue;
+          if (proto.starts_with(':')) proto.remove_prefix(1);
+
+          const std::string proto_fqn =
+            build_file->package.QualifiedFile(proto);
+          const std::string_view maybe_stripped =
+            StripIfNeeded(proto_fqn, proto_lib.strip_import_prefix);
+          const std::string key = KeyTransform(maybe_stripped, suffix_index);
+          InsertLibAndAliasesToTargetSet(key, *target, aliased_by_index,
+                                         result);
+        }
+      });
+  }
+
+  return result;
+}
+
 ProvidedFromTargetSet ExtractComponentToTargetMapping(
   const ParsedProject &project, ExtractComponent which,
   bool only_physical_files, std::ostream &info_out) {

--- a/bant/explore/header-providers.h
+++ b/bant/explore/header-providers.h
@@ -50,6 +50,14 @@ ProvidedFromTargetSet ExtractExpandedHeaderToLibMapping(
   const ParsedProject &project, std::ostream &info_out,
   bool suffix_index = false);
 
+// Create a mapping of .proto source files to their providing proto_library()
+// targets. Used for proto-level DWYU checking (import statements in .proto
+// files vs deps of proto_library rules).
+// If "suffix_index" is set, output is compatible with FindBySuffix().
+ProvidedFromTargetSet ExtractProtoToProtoLibMapping(
+  const ParsedProject &project, std::ostream &info_out,
+  bool suffix_index = false);
+
 // Unlike the Expanded*, this is much simpler, as we don't deal with multiple
 // search paths. Just extract the mentioned component. If "only_physical_files"
 // is on, only emit them if these are files in the filesystem (unlike

--- a/bant/tool/dwyu-internal.h
+++ b/bant/tool/dwyu-internal.h
@@ -28,10 +28,12 @@
 #include "absl/container/btree_set.h"
 #include "bant/explore/header-providers.h"
 #include "bant/explore/query-utils.h"
+#include "bant/frontend/named-content.h"
 #include "bant/frontend/parsed-project.h"
 #include "bant/session.h"
 #include "bant/tool/edit-callback.h"
 #include "bant/types-bazel.h"
+#include "bant/util/stat.h"
 
 namespace bant {
 // The DWYUGenerator is the underlying implementation, for which
@@ -86,14 +88,46 @@ class DWYUGenerator {
     const std::vector<std::string_view> &sources,
     bool *all_headers_accounted_for);
 
+  // Similar to DependenciesNeededBySources but for proto_library targets.
+  // Reads .proto source files and extracts import statements to determine
+  // which proto_library deps are actually needed.
+  std::vector<absl::btree_set<BazelTarget>> DependenciesNeededByProtoSources(
+    const BazelTarget &target, const ParsedBuildFile &build_file,
+    const std::vector<std::string_view> &sources,
+    bool *all_imports_accounted_for);
+
   void CreateEditsForTarget(const BazelTarget &target,
                             const query::Result &details,
                             const ParsedBuildFile &build_file);
+
+  // Read a source file and update stats. Returns nullopt on failure after
+  // logging the issue and setting *all_accounted = false.
+  std::optional<SourceFile> ReadSourceForDWYU(std::string_view src_name,
+                                              const BazelTarget &target,
+                                              const ParsedBuildFile &build_file,
+                                              Stat &read_stats,
+                                              bool *all_accounted);
+
+  // Log "unknown provider" warning for an unresolved include/import.
+  void LogUnknownProvider(const NamedLineIndexedContent &source,
+                          std::string_view ref_file,
+                          std::string_view ref_keyword);
+
+  // Filter alternatives to only visible targets and append to result.
+  void AddVisibleAlternatives(
+    const BazelTarget &target, const absl::btree_set<BazelTarget> &alternatives,
+    std::vector<absl::btree_set<BazelTarget>> &result);
+
+  // Like AddVisibleAlternatives but also considers stratum for cc targets.
+  void AddVisibleAlternativesWithStratum(
+    const BazelTarget &target, const absl::btree_set<BazelTarget> &alternatives,
+    std::vector<absl::btree_set<BazelTarget>> &result);
 
   Session &session_;
   const ParsedProject &project_;
   const EditCallback emit_deps_edit_;
   ProvidedFromTargetSet headers_from_libs_;
+  ProvidedFromTargetSet protos_from_libs_;
   ProvidedFromTarget files_from_genrules_;
   absl::btree_map<BazelTarget, query::Result> known_libs_;
 };

--- a/bant/tool/dwyu.cc
+++ b/bant/tool/dwyu.cc
@@ -179,6 +179,7 @@ void DWYUGenerator::InitKnownLibraries() {
     query::FindTargets(parsed_package->ast,
                        {"cc_library", "alias",  // The common ones
                         "cc_proto_library", "grpc_cc_library",  // specialized
+                        "proto_library",                        // proto DWYU
                         "cc_test"},  // also indexing test for testonly check.
                        [&](const query::Result &target) {
                          auto self =
@@ -306,7 +307,83 @@ int DWYUGenerator::GetStratum(const BazelTarget &target) const {
   return entry->first.stratum;
 }
 
-// TODO: needs to be shorter and broken up into various functions.
+std::optional<DWYUGenerator::SourceFile> DWYUGenerator::ReadSourceForDWYU(
+  std::string_view src_name, const BazelTarget &target,
+  const ParsedBuildFile &build_file, Stat &read_stats, bool *all_accounted) {
+  const std::string source_file =
+    build_file.package.FullyQualifiedFile(project_.workspace(), src_name);
+  std::optional<SourceFile> source_content;
+  {
+    const ScopedTimer timer(&read_stats.duration);
+    source_content = TryOpenFile(source_file);
+  }
+  if (!source_content.has_value()) {
+    std::ostream &info_out = session_.info();
+    project_.Loc(info_out, src_name)
+      << " Can not read source '" << source_file << "' for target " << target;
+    const auto from_genrule = files_from_genrules_.find(source_file);
+    if (from_genrule != files_from_genrules_.end()) {
+      info_out << "; Run genrule `bazel build " << from_genrule->second
+               << "` first.\n";
+    } else {
+      info_out << " -- Missing ?\n";
+    }
+    *all_accounted = false;
+  }
+  return source_content;
+}
+
+void DWYUGenerator::LogUnknownProvider(const NamedLineIndexedContent &source,
+                                       std::string_view ref_file,
+                                       std::string_view ref_keyword) {
+  if (!session_.flags().verbose) return;
+  std::ostream &info_out = session_.info();
+  source.Loc(info_out, ref_file)
+    << " " << ref_keyword << " \"" << ref_file << "\"\n";
+  source.Loc(info_out, ref_file)
+    << Red(session_) << "    ?      ^ unknown provider "
+    << "-- Missing or from non-standard bazel-rule ?" << Norm(session_) << "\n";
+}
+
+void DWYUGenerator::AddVisibleAlternatives(
+  const BazelTarget &target, const absl::btree_set<BazelTarget> &alternatives,
+  std::vector<absl::btree_set<BazelTarget>> &result) {
+  absl::btree_set<BazelTarget> visible;
+  for (const BazelTarget &t : alternatives) {
+    if (CanSee(target, t, nullptr)) {
+      visible.emplace(t);
+    }
+  }
+  if (!visible.empty()) {
+    result.push_back(std::move(visible));
+  }
+}
+
+void DWYUGenerator::AddVisibleAlternativesWithStratum(
+  const BazelTarget &target, const absl::btree_set<BazelTarget> &alternatives,
+  std::vector<absl::btree_set<BazelTarget>> &result) {
+  Range stratum_range;
+  std::vector<BazelTarget> temp_result;
+  for (const BazelTarget &t : alternatives) {
+    if (CanSee(target, t, nullptr)) {
+      const int stratum = GetStratum(t);
+      stratum_range.Update(stratum);
+      if (stratum <= stratum_range.min_value) {
+        temp_result.emplace_back(t);
+      }
+    }
+  }
+  if (temp_result.empty()) return;
+  auto &result_set = result.emplace_back();
+  for (const BazelTarget &t : temp_result) {
+    if (stratum_range.min_value != stratum_range.max_value &&
+        GetStratum(t) != stratum_range.min_value) {
+      continue;
+    }
+    result_set.emplace(t);
+  }
+}
+
 std::vector<absl::btree_set<BazelTarget>>
 DWYUGenerator::DependenciesNeededBySources(
   const BazelTarget &target, const ParsedBuildFile &build_file,
@@ -317,10 +394,6 @@ DWYUGenerator::DependenciesNeededBySources(
 
   std::ostream &info_out = session_.info();
   size_t total_size = 0;
-
-  // Already provided targets we don't need to emit anymore.
-  std::set<BazelTarget> already_provided;
-  already_provided.insert(target);
 
   // Log providers if super verbose -vvv
   auto maybe_log = [&](const NamedLineIndexedContent &source,
@@ -352,58 +425,14 @@ DWYUGenerator::DependenciesNeededBySources(
     source_logged_already = true;
   };
 
-  // Add alternatives to the result we return, but filtering to only
-  // include visible targets.
   std::vector<absl::btree_set<BazelTarget>> result;
-  auto add_to_result = [&](const absl::btree_set<BazelTarget> &alternatives) {
-    Range stratum_range;
-    // Add all visible targets. If there alternatives with different stratum
-    // values, only keep the ones with the lowest value.
-    std::vector<BazelTarget> temp_result;
-    for (const BazelTarget &t : alternatives) {
-      if (CanSee(target, t, nullptr)) {
-        const int stratum = GetStratum(t);
-        stratum_range.Update(stratum);
-        if (stratum <= stratum_range.min_value) {
-          temp_result.emplace_back(t);
-        }
-      }
-    }
-
-    if (temp_result.empty()) return;
-    auto &result_set = result.emplace_back();
-    for (const BazelTarget &t : temp_result) {
-      if (stratum_range.min_value != stratum_range.max_value &&
-          GetStratum(t) != stratum_range.min_value) {
-        // TODO: maybe even make this a removal candidate ?
-        continue;
-      }
-      result_set.emplace(t);
-    }
-  };
 
   for (const std::string_view src_name : sources) {
     source_logged_already = false;
-    const std::string source_file =
-      build_file.package.FullyQualifiedFile(project_.workspace(), src_name);
-    std::optional<DWYUGenerator::SourceFile> source_content;
-    {
-      const ScopedTimer timer(&source_read_stats.duration);
-      source_content = TryOpenFile(source_file);
-    }
-    if (!source_content.has_value()) {
-      project_.Loc(info_out, src_name)
-        << " Can not read source '" << source_file << "' for target " << target;
-      const auto from_genrule = files_from_genrules_.find(source_file);
-      if (from_genrule != files_from_genrules_.end()) {
-        info_out << "; Run genrule `bazel build " << from_genrule->second
-                 << "` first.\n";
-      } else {
-        info_out << " -- Missing ?\n";
-      }
-      *all_headers_accounted_for = false;
-      continue;
-    }
+    auto source_content =
+      ReadSourceForDWYU(src_name, target, build_file, source_read_stats,
+                        all_headers_accounted_for);
+    if (!source_content.has_value()) continue;
 
     if (session_.flags().verbose > 1) {
       maybe_log_sourcereference(src_name, source_content->path, target);
@@ -450,7 +479,8 @@ DWYUGenerator::DependenciesNeededBySources(
             << " same-suffix path '" << found_result.match << "'\n";
         }
         maybe_log(source, inc_file, *found_result.target_set);
-        add_to_result(*found_result.target_set);
+        AddVisibleAlternativesWithStratum(target, *found_result.target_set,
+                                          result);
         continue;
       }
 
@@ -465,7 +495,7 @@ DWYUGenerator::DependenciesNeededBySources(
             << "Consider FQN relative to project root.\n";
         }
         maybe_log(source, inc_file, *found->target_set);
-        add_to_result(*found->target_set);
+        AddVisibleAlternativesWithStratum(target, *found->target_set, result);
         continue;
       }
 
@@ -496,12 +526,87 @@ DWYUGenerator::DependenciesNeededBySources(
         // Until all common reasons why we don't find a provider is resolved,
         // report.
         maybe_log_sourcereference(src_name, source_content->path, target);
-        source.Loc(info_out, inc_file) << " #include \"" << inc_file << "\"\n";
-        source.Loc(info_out, inc_file)
-          << Red(session_) << "    ?      ^ unknown provider "
-          << "-- Missing or from non-standard bazel-rule ?" << Norm(session_)
-          << "\n";
       }
+      LogUnknownProvider(source, inc_file, "#include");
+    }
+  }
+
+  source_read_stats.AddBytesProcessed(total_size);
+  source_grep_stats.AddBytesProcessed(total_size);
+  return result;
+}
+
+std::vector<absl::btree_set<BazelTarget>>
+DWYUGenerator::DependenciesNeededByProtoSources(
+  const BazelTarget &target, const ParsedBuildFile &build_file,
+  const std::vector<std::string_view> &sources,
+  bool *all_imports_accounted_for) {
+  Stat &source_read_stats =
+    session_.GetStatsFor("read(proto source)", "sources");
+  Stat &source_grep_stats =
+    session_.GetStatsFor("Grep'ed for import", "sources");
+
+  std::ostream &info_out = session_.info();
+  size_t total_size = 0;
+
+  // We log the source on -vv, but sometimes also in less verbose
+  // situations. Only once per source.
+  bool source_logged_already = false;
+  auto maybe_log_sourcereference = [&](std::string_view src_name,
+                                       const std::string &path,
+                                       const BazelTarget &target) {
+    if (source_logged_already) return;
+    project_.Loc(info_out, src_name)
+      << " `" << path << "` import dependency check (" << target << ")\n";
+    source_logged_already = true;
+  };
+
+  std::vector<absl::btree_set<BazelTarget>> result;
+
+  for (const std::string_view src_name : sources) {
+    source_logged_already = false;
+    auto source_content =
+      ReadSourceForDWYU(src_name, target, build_file, source_read_stats,
+                        all_imports_accounted_for);
+    if (!source_content.has_value()) continue;
+
+    if (session_.flags().verbose > 1) {
+      maybe_log_sourcereference(src_name, source_content->path, target);
+    }
+    ++source_read_stats.count;
+    ++source_grep_stats.count;
+    total_size += source_content->content.size();
+    NamedLineIndexedContent source(source_content->path,
+                                   source_content->content);
+    std::vector<std::string_view> imports;
+    {
+      const ScopedTimer timer(&source_grep_stats.duration);
+      imports = ExtractProtoImports(&source);
+    }
+
+    for (const std::string_view imp_file : imports) {
+      if (IsHeaderInList(imp_file, sources, target.package.path)) {
+        continue;
+      }
+
+      if (const auto &found = FindBySuffix(protos_from_libs_, imp_file);
+          found.has_value()) {
+        if (session_.flags().verbose >= 3) {
+          source.Loc(info_out, imp_file) << " import \"" << imp_file << "\"\n";
+          for (const BazelTarget &p : *found->target_set) {
+            source.Loc(info_out, imp_file) << "    | " << p << "\n";
+          }
+        }
+        AddVisibleAlternatives(target, *found->target_set, result);
+        continue;
+      }
+
+      *all_imports_accounted_for = false;
+
+      if (session_.flags().verbose) {
+        maybe_log_sourcereference(src_name, source_content->path, target);
+      }
+      LogUnknownProvider(source, imp_file, "import");
     }
   }
 
@@ -515,18 +620,25 @@ void DWYUGenerator::CreateEditsForTarget(const BazelTarget &target,
                                          const ParsedBuildFile &build_file) {
   if (details.bant_skip_dependency_check) return;
 
-  // Looking at the include files the sources reference, map these back
+  // Looking at the include/import files the sources reference, map these back
   // to the dependencies that provide them: these are the deps we
   // needed.
   bool all_header_deps_known = true;
 
+  const bool is_proto_library = (details.rule == "proto_library");
+
   // Collect sources and headers provided by this library.
   auto sources = query::ExtractStringList(details.srcs_list);
-  query::AppendStringList(details.hdrs_list, sources);
+  if (!is_proto_library) {
+    query::AppendStringList(details.hdrs_list, sources);
+  }
 
-  // Grep for all includes they use to determine which deps we need
-  auto deps_needed = DependenciesNeededBySources(target, build_file, sources,
-                                                 &all_header_deps_known);
+  // Grep for all includes/imports they use to determine which deps we need
+  auto deps_needed = is_proto_library
+                       ? DependenciesNeededByProtoSources(
+                           target, build_file, sources, &all_header_deps_known)
+                       : DependenciesNeededBySources(
+                           target, build_file, sources, &all_header_deps_known);
   deps_needed = MinimizeDependencySet(deps_needed);
   OneToOne<BazelTarget, BazelTarget> checked_off_by;
   auto IsNeededInSourcesAndCheckOff = [&](const BazelTarget &target) -> bool {
@@ -663,6 +775,32 @@ std::vector<std::string_view> ExtractCCIncludes(NamedLineIndexedContent *src) {
   return result;
 }
 
+std::vector<std::string_view> ExtractProtoImports(
+  NamedLineIndexedContent *src) {
+  //          comment  | import statement
+  static const LazyRE2 kImportRe{
+    R"/((?m)(\/\/.*$|^\s*import\s+"([0-9a-zA-Z_/\-\.]+\.proto)"))/"};
+
+  std::vector<std::string_view> result;
+  std::string_view run = src->content();
+  std::string_view import_path;
+  std::string_view outer;
+  while (RE2::FindAndConsume(&run, *kImportRe, &outer, &import_path)) {
+    if (outer.starts_with("//")) {
+      // ignore comment.
+    } else if (!import_path.empty()) {
+      result.push_back(import_path);
+    }
+  }
+
+  if (!result.empty()) {
+    const std::string_view range(src->content().begin(),
+                                 result.back().end() - src->content().begin());
+    src->mutable_line_index()->InitializeFromStringView(range);
+  }
+  return result;
+}
+
 DWYUGenerator::DWYUGenerator(Session &session, const ParsedProject &project,
                              EditCallback emit_deps_edit)
     : session_(session),
@@ -674,6 +812,8 @@ DWYUGenerator::DWYUGenerator(Session &session, const ParsedProject &project,
   headers_from_libs_ =
     ExtractExpandedHeaderToLibMapping(project, session.info(),
                                       /*suffix_index=*/true);
+  protos_from_libs_ = ExtractProtoToProtoLibMapping(project, session.info(),
+                                                    /*suffix_index=*/true);
   files_from_genrules_ = ExtractGeneratedFromGenrule(project, session.info());
   InitKnownLibraries();
   stats.count = known_libs_.size();
@@ -687,7 +827,8 @@ size_t DWYUGenerator::CreateEditsForPattern(const BazelTargetMatcher &pattern) {
       continue;
     }
     query::FindTargets(
-      parsed_package->ast, {"cc_library", "cc_binary", "cc_test"},
+      parsed_package->ast,
+      {"cc_library", "cc_binary", "cc_test", "proto_library"},
       [&](const query::Result &details) {
         auto target = current_package.QualifiedTarget(details.name);
         if (!target.has_value() || !pattern.Match(*target)) {
@@ -715,8 +856,9 @@ size_t CreateDependencyEdits(Session &session, const ParsedProject &project,
   session.info() << "Checked DWYU on " << target_count << " targets.";
   if (target_count == 0 && pattern.HasFilter()) {
     session.info()
-      << "\nNote: No cc_library/cc_binary/cc_test targets matched the"
-         " pattern. Target might not exist or uses an unknown custom rule."
+      << "\nNote: No cc_library/cc_binary/cc_test/proto_library targets"
+         " matched the pattern. Target might not exist or uses an unknown"
+         " custom rule."
          "\nConsider adding a macro to your project's .bant-macros file.";
   }
   if (edits_emitted) {

--- a/bant/tool/dwyu.h
+++ b/bant/tool/dwyu.h
@@ -35,6 +35,11 @@ namespace bant {
 // Initialize the line index in src to be able to refer back to origainal.
 std::vector<std::string_view> ExtractCCIncludes(NamedLineIndexedContent *src);
 
+// Scan a .proto file and extract import paths from "import" statements.
+// Returns the import paths (e.g. "foo/bar.proto") from lines like:
+//   import "foo/bar.proto";
+std::vector<std::string_view> ExtractProtoImports(NamedLineIndexedContent *src);
+
 // Look through the sources mentioned in the file, check what they include
 // and determine what dependencies need to be added/removed.
 // Input should be an elaborated project for best availability of inspected

--- a/bant/tool/dwyu_test.cc
+++ b/bant/tool/dwyu_test.cc
@@ -915,6 +915,83 @@ cc_binary(
   }
 }
 
+TEST(DWYUTest, ProtoImportsAreExtracted) {
+  constexpr std::string_view kTestProto = R"pb(
+    syntax = "proto3"
+    ;
+
+package foo;
+
+// import "not/extracted.proto";
+import "path/to/dependency.proto";
+import "other/dep.proto";
+
+message Bar {
+  string name = 1;
+}
+)pb";
+  NamedLineIndexedContent scanned_src("<proto>", kTestProto);
+  const auto imports = ExtractProtoImports(&scanned_src);
+  EXPECT_THAT(imports,
+              ElementsAre("path/to/dependency.proto", "other/dep.proto"));
+}
+
+TEST(DWYUTest, Remove_SuperfluousProtoLibraryDependency) {
+  ParsedProjectTestUtil pp;
+  pp.Add("//some/path", R"(
+proto_library(
+  name = "foo_proto",
+  srcs = ["foo.proto"],
+)
+
+proto_library(
+  name = "bar_proto",
+  srcs = ["bar.proto"],
+)
+
+proto_library(
+  name = "baz_proto",
+  srcs = ["baz.proto"],
+  deps = [
+    ":foo_proto",
+    ":bar_proto",
+  ],
+)
+)");
+
+  DWYUTestFixture tester(pp.project());
+  tester.ExpectRemove(":bar_proto");  // not imported
+  tester.AddSource("some/path/baz.proto", R"(
+syntax = "proto3";
+import "some/path/foo.proto";
+)");
+  tester.RunForTarget("//some/path:baz_proto");
+}
+
+TEST(DWYUTest, Add_MissingProtoLibraryDependency) {
+  ParsedProjectTestUtil pp;
+  pp.Add("//some/path", R"(
+proto_library(
+  name = "foo_proto",
+  srcs = ["foo.proto"],
+)
+
+proto_library(
+  name = "baz_proto",
+  srcs = ["baz.proto"],
+  # Missing dep on :foo_proto
+)
+)");
+
+  DWYUTestFixture tester(pp.project());
+  tester.ExpectAdd(":foo_proto");
+  tester.AddSource("some/path/baz.proto", R"(
+syntax = "proto3";
+import "some/path/foo.proto";
+)");
+  tester.RunForTarget("//some/path:baz_proto");
+}
+
 // TODO: stratum test.
 //
 }  // namespace bant

--- a/bant/workspace.cc
+++ b/bant/workspace.cc
@@ -143,10 +143,21 @@ static std::optional<int> LoadWorkspaceFromFile(Session &session,
       // Check for both if we have a version.
       std::vector<std::string> search_dirs;
       auto version = query::FindKWArgAsStringView(result.node, "version");
+      auto repo_name = query::FindKWArgAsStringView(result.node, "repo_name");
       if (version.has_value()) {
         search_dirs.push_back(absl::StrCat(result.name, "~", *version));
       }
       search_dirs.emplace_back(result.name);
+
+      // When repo_name is set in bazel_dep(), bazel may use it as the
+      // external directory name instead of the module name.
+      if (repo_name.has_value() && *repo_name != result.name) {
+        if (version.has_value()) {
+          search_dirs.push_back(absl::StrCat(*repo_name, "~", *version));
+        }
+        search_dirs.emplace_back(*repo_name);
+        search_dirs.push_back(absl::StrCat(*repo_name, "+"));
+      }
 
       // Also a plausible location when archive_override() is used:
       search_dirs.push_back(absl::StrCat(result.name, "+"));  // bazel8-ism
@@ -182,7 +193,6 @@ static std::optional<int> LoadWorkspaceFromFile(Session &session,
         return;
       }
 
-      auto repo_name = query::FindKWArgAsStringView(result.node, "repo_name");
       VersionedProject project;
       project.project = repo_name.has_value() ? *repo_name : result.name;
       if (version.has_value()) {


### PR DESCRIPTION
Three improvements to DWYU analysis:

1. Proto DWYU — `proto_library` targets are now analyzed for unused/missing deps by parsing import statements in `.proto` source files, just like `#include` analysis for C++ targets.
2. `repo_name` support in `bazel_dep()` — When a `bazel_dep()` has repo_name set (e.g. `bazel_dep(name = "...", repo_name = "tsl")`), the external directory is now searched using both the module name and the repo_name. This fixes resolution of repos like `@tsl` (in XLA) that are referenced by `repo_name` rather than module name.