### PR TITLE
Guard resize_and_overwrite by library feature-test macro, not __cplusplus

### DIFF
--- a/bant/util/filesystem.cc
+++ b/bant/util/filesystem.cc
@@ -182,7 +182,7 @@ std::optional<std::string> Filesystem::ReadFileToString(std::string_view path) {
     success = (bytes_left == 0);
     return filesize;
   };
-#if __cplusplus >= 202100L  // Implemented in gcc since 202100
+#if defined(__cpp_lib_string_resize_and_overwrite)  // library support, not language level
   content.resize_and_overwrite(filesize, copy_file_to_buffer);
 #else
   content.resize(filesize);


### PR DESCRIPTION
Building bant (0.2.10 from the BCR, and current `main`) with a hermetic clang toolchain at `-std=c++23`/`c++26` against a libstdc++ that predates P1072 fails:

```
bant/util/filesystem.cc:186:11: error: no member named 'resize_and_overwrite' in 'std::basic_string<char>'
```

`__cplusplus >= 202100L` tests the *language* level, but `std::string::resize_and_overwrite` is a *library* feature — libstdc++ implemented it much later than libc++/MSVC, so clang + older libstdc++ (e.g. Ubuntu 22.04's) passes the guard and then selects a member that doesn't exist. The feature-test macro `__cpp_lib_string_resize_and_overwrite` (defined by `<string>`, already directly included here, iff the member is implemented) is the precise guard, and the existing `#else` fallback already covers its absence.

One-line change; no behavior difference on toolchains whose library implements the member.