### PR TITLE
List Comprehension: Make iterating over containers containing tuples possible

### DIFF
--- a/bant/frontend/elaboration.cc
+++ b/bant/frontend/elaboration.cc
@@ -595,9 +595,38 @@ class SimpleElaborator : public BaseNodeReplacementVisitor {
       iterate_over = ExtractMapItems(iterate_over, MapExtract::kKeys);
     }
 
+    std::function<bool(Node*)> verify_vars = [&](Node* n) -> bool {
+      if (n->CastAsIdentifier()) return true;
+      if (List* l = n->CastAsList()) {
+        for (Node* c : *l) {
+          if (!verify_vars(c)) return false;
+        }
+        return true;
+      }
+      return false;
+    };
+
     for (Node *is_var : *var_tuple) {
-      if (!is_var->CastAsIdentifier()) return for_node;  // verify all variables
+      if (!verify_vars(is_var)) return for_node;  // verify all variables
     }
+
+    std::function<void(Node*, Node*, query::KwMap*)> unpack = [&](Node* target, Node* value, query::KwMap* map) {
+      if (Identifier* id = target->CastAsIdentifier()) {
+        (*map)[id->id()] = value;
+        return;
+      }
+      if (List* target_list = target->CastAsList()) {
+        if (List* value_list = value->CastAsList()) {
+          List::iterator target_it = target_list->begin();
+          List::iterator value_it = value_list->begin();
+          while (target_it != target_list->end() && value_it != value_list->end()) {
+            unpack(*target_it, *value_it, map);
+            ++target_it;
+            ++value_it;
+          }
+        }
+      }
+    };
 
     query::KwMap varmap;
     for (Node *element : *iterate_over) {
@@ -608,14 +637,12 @@ class SimpleElaborator : public BaseNodeReplacementVisitor {
           values && var_tuple->size() > 1) {
         List::iterator value_it = values->begin();
         while (name_it != var_tuple->end() && value_it != values->end()) {
-          const Identifier *const id = (*name_it)->CastAsIdentifier();
-          varmap[id->id()] = *value_it;
+          unpack(*name_it, *value_it, &varmap);
           ++name_it;
           ++value_it;
         }
-      } else {  // Single value case for (a) in [1, 2, 3]
-        const Identifier *const id = (*name_it)->CastAsIdentifier();
-        varmap[id->id()] = element;
+      } else if (var_tuple->size() == 1) {  // Single value case for (a) in [1, 2, 3]
+        unpack(*name_it, element, &varmap);
       }
 
       Node *substituted =

--- a/bant/frontend/elaboration.cc
+++ b/bant/frontend/elaboration.cc
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <functional>
 #include <initializer_list>
 #include <optional>
 #include <ostream>
@@ -595,10 +596,10 @@ class SimpleElaborator : public BaseNodeReplacementVisitor {
       iterate_over = ExtractMapItems(iterate_over, MapExtract::kKeys);
     }
 
-    std::function<bool(Node*)> verify_vars = [&](Node* n) -> bool {
+    std::function<bool(Node *)> verify_vars = [&](Node *n) -> bool {
       if (n->CastAsIdentifier()) return true;
-      if (List* l = n->CastAsList()) {
-        for (Node* c : *l) {
+      if (List *l = n->CastAsList()) {
+        for (Node *c : *l) {
           if (!verify_vars(c)) return false;
         }
         return true;
@@ -610,23 +611,25 @@ class SimpleElaborator : public BaseNodeReplacementVisitor {
       if (!verify_vars(is_var)) return for_node;  // verify all variables
     }
 
-    std::function<void(Node*, Node*, query::KwMap*)> unpack = [&](Node* target, Node* value, query::KwMap* map) {
-      if (Identifier* id = target->CastAsIdentifier()) {
-        (*map)[id->id()] = value;
-        return;
-      }
-      if (List* target_list = target->CastAsList()) {
-        if (List* value_list = value->CastAsList()) {
-          List::iterator target_it = target_list->begin();
-          List::iterator value_it = value_list->begin();
-          while (target_it != target_list->end() && value_it != value_list->end()) {
-            unpack(*target_it, *value_it, map);
-            ++target_it;
-            ++value_it;
+    std::function<void(Node *, Node *, query::KwMap *)> unpack =
+      [&](Node *target, Node *value, query::KwMap *map) {
+        if (Identifier *id = target->CastAsIdentifier()) {
+          (*map)[id->id()] = value;
+          return;
+        }
+        if (List *target_list = target->CastAsList()) {
+          if (List *value_list = value->CastAsList()) {
+            List::iterator target_it = target_list->begin();
+            List::iterator value_it = value_list->begin();
+            while (target_it != target_list->end() &&
+                   value_it != value_list->end()) {
+              unpack(*target_it, *value_it, map);
+              ++target_it;
+              ++value_it;
+            }
           }
         }
-      }
-    };
+      };
 
     query::KwMap varmap;
     for (Node *element : *iterate_over) {
@@ -641,7 +644,8 @@ class SimpleElaborator : public BaseNodeReplacementVisitor {
           ++name_it;
           ++value_it;
         }
-      } else if (var_tuple->size() == 1) {  // Single value case for (a) in [1, 2, 3]
+      } else if (var_tuple->size() == 1) {
+        // Single value case for (a) in [1, 2, 3]
         unpack(*name_it, element, &varmap);
       }
 

--- a/bant/frontend/elaboration_test.cc
+++ b/bant/frontend/elaboration_test.cc
@@ -335,7 +335,6 @@ LIST_WITH_TUPLES = [ ("hello", (2, 3)),
 OUT = [ "hello b=2, c=3", "world b=5, c=6" ]
 )lc-result");
   EXPECT_EQ(result.first, result.second);
-
 }
 TEST_F(ElaborationTest, ListComprehensionTupleFromMap) {
   auto result = ElabAndPrint(

--- a/bant/frontend/elaboration_test.cc
+++ b/bant/frontend/elaboration_test.cc
@@ -322,6 +322,36 @@ E = [11, 12, 20, 21, 22, 40]
   EXPECT_EQ(result.first, result.second);
 }
 
+TEST_F(ElaborationTest, ListComprehensionTuple) {
+  auto result = ElabAndPrint(
+    R"lc-in(
+LIST_WITH_TUPLES = [ ("hello", (2, 3)),
+                     ("world", (5, 6)) ]
+OUT = [ "{} b={}, c={}".format(a, b, c) for a, (b, c) in LIST_WITH_TUPLES ]
+)lc-in",
+    R"lc-result(
+LIST_WITH_TUPLES = [ ("hello", (2, 3)),
+                     ("world", (5, 6)) ]
+OUT = [ "hello b=2, c=3", "world b=5, c=6" ]
+)lc-result");
+  EXPECT_EQ(result.first, result.second);
+
+}
+TEST_F(ElaborationTest, ListComprehensionTupleFromMap) {
+  auto result = ElabAndPrint(
+    R"lc-in(
+MAP = { "hello" : (3, 4),
+        "world" : (5, 6) }
+OUT = [ "{} b={}, c={}".format(a, b, c) for a, (b, c) in MAP.items() ]
+)lc-in",
+    R"lc-result(
+MAP = { "hello" : (3, 4),
+        "world" : (5, 6) }
+OUT = [ "hello b=3, c=4", "world b=5, c=6" ]
+)lc-result");
+  EXPECT_EQ(result.first, result.second);
+}
+
 TEST_F(ElaborationTest, ListComprehensionIf) {
   auto result = ElabAndPrint(
     R"lc-in(

--- a/bant/frontend/elaboration_test.cc
+++ b/bant/frontend/elaboration_test.cc
@@ -352,6 +352,21 @@ OUT = [ "hello b=3, c=4", "world b=5, c=6" ]
   EXPECT_EQ(result.first, result.second);
 }
 
+TEST_F(ElaborationTest, ListComprehensionDeeplyNestedTuple) {
+  auto result = ElabAndPrint(
+    R"lc-in(
+DEEP_LIST = [ (("a", (1, 2)), ("x", 9)),
+              (("b", (3, 4)), ("y", 8)) ]
+OUT = [ "{}_{} {}_{}_{}".format(a, d, b, c, e) for (a, (b, c)), (d, e) in DEEP_LIST ]
+)lc-in",
+    R"lc-result(
+DEEP_LIST = [ (("a", (1, 2)), ("x", 9)),
+              (("b", (3, 4)), ("y", 8)) ]
+OUT = [ "a_x 1_2_9", "b_y 3_4_8" ]
+)lc-result");
+  EXPECT_EQ(result.first, result.second);
+}
+
 TEST_F(ElaborationTest, ListComprehensionIf) {
   auto result = ElabAndPrint(
     R"lc-in(

--- a/bant/frontend/parser.cc
+++ b/bant/frontend/parser.cc
@@ -555,9 +555,9 @@ class Parser::Impl {
           Make<List>(List::Type::kTuple),
           [&]() { return ParseOptionalIdentifierOrTuple(); }, TokenType::kIn);
 
-        // If the entire variable tuple was enclosed in parentheses, e.g. for (a, b) in ...,
-        // ParseList will return a list of size 1 where the only element is a tuple.
-        // We unwrap it to match the flat structure [a, b].
+        // If the entire variable tuple was enclosed in parentheses, e.g. for
+        // (a, b) in ..., ParseList will return a list of size 1 where the only
+        // element is a tuple. We unwrap it to match the flat structure [a, b].
         if (variable_tuple->size() == 1) {
           if (List *inner_tuple = (*variable_tuple->begin())->CastAsList()) {
             variable_tuple = inner_tuple;

--- a/bant/frontend/parser.cc
+++ b/bant/frontend/parser.cc
@@ -551,21 +551,17 @@ class Parser::Impl {
       if (peek_type == TokenType::kFor) {
         const Token start_of_for = scanner_->Next();
 
-        List *variable_tuple = nullptr;
-        if (scanner_->Peek().type == '(') {  // (i, j, k) case.
-          scanner_->Next();                  // Consume open tuple '('
-          variable_tuple = ParseList(        // .. parse until we see close ')'
-            Make<List>(List::Type::kTuple),
-            [&]() { return ParseOptionalIdentifierOrTuple(); },
-            TokenType::kCloseParen);
-          const Token expected_in = scanner_->Next();
-          if (expected_in.type != TokenType::kIn) {
-            ErrAt(expected_in) << "expected 'in' after variable tuple\n";
+        List *variable_tuple = ParseList(
+          Make<List>(List::Type::kTuple),
+          [&]() { return ParseOptionalIdentifierOrTuple(); }, TokenType::kIn);
+
+        // If the entire variable tuple was enclosed in parentheses, e.g. for (a, b) in ...,
+        // ParseList will return a list of size 1 where the only element is a tuple.
+        // We unwrap it to match the flat structure [a, b].
+        if (variable_tuple->size() == 1) {
+          if (List *inner_tuple = (*variable_tuple->begin())->CastAsList()) {
+            variable_tuple = inner_tuple;
           }
-        } else {  // i, j, k case. Here the expected list end token is 'in'
-          variable_tuple = ParseList(
-            Make<List>(List::Type::kTuple),
-            [&]() { return ParseOptionalIdentifierOrTuple(); }, TokenType::kIn);
         }
 
         Node *const values_to_iterate_over = ParseExpression(false, false);

--- a/bant/frontend/parser.cc
+++ b/bant/frontend/parser.cc
@@ -512,6 +512,31 @@ class Parser::Impl {
     return nullptr;
   }
 
+  // Parse next thing if it is an identifier, or a tuple/list of identifiers.
+  Node *ParseOptionalIdentifierOrTuple() {
+    LOG_ENTER();
+    const TokenType type = scanner_->Peek().type;
+    if (type == TokenType::kIdentifier) {
+      const Token tok = scanner_->Next();
+      return Make<Identifier>(tok.text);
+    }
+    if (type == '(') {
+      scanner_->Next();
+      return ParseList(
+        Make<List>(List::Type::kTuple),
+        [&]() { return ParseOptionalIdentifierOrTuple(); },
+        TokenType::kCloseParen);
+    }
+    if (type == '[') {
+      scanner_->Next();
+      return ParseList(
+        Make<List>(List::Type::kList),
+        [&]() { return ParseOptionalIdentifierOrTuple(); },
+        TokenType::kCloseSquare);
+    }
+    return nullptr;
+  }
+
   // Read for-in constructs until we hit expected_end_token.
   // Creates a left-recursive tree of 'for' BinOpNodes in which the thing
   // to iterate over is on the left, and the variable-tuple in-expression
@@ -531,7 +556,7 @@ class Parser::Impl {
           scanner_->Next();                  // Consume open tuple '('
           variable_tuple = ParseList(        // .. parse until we see close ')'
             Make<List>(List::Type::kTuple),
-            [&]() { return ParseOptionalIdentifier(); },
+            [&]() { return ParseOptionalIdentifierOrTuple(); },
             TokenType::kCloseParen);
           const Token expected_in = scanner_->Next();
           if (expected_in.type != TokenType::kIn) {
@@ -540,7 +565,7 @@ class Parser::Impl {
         } else {  // i, j, k case. Here the expected list end token is 'in'
           variable_tuple = ParseList(
             Make<List>(List::Type::kTuple),
-            [&]() { return ParseOptionalIdentifier(); }, TokenType::kIn);
+            [&]() { return ParseOptionalIdentifierOrTuple(); }, TokenType::kIn);
         }
 
         Node *const values_to_iterate_over = ParseExpression(false, false);

--- a/bant/frontend/parser_test.cc
+++ b/bant/frontend/parser_test.cc
@@ -477,6 +477,37 @@ TEST_F(ParserTest, ParseListComprehension) {
 )")));
 }
 
+TEST_F(ParserTest, ParseListComprehensionTuple) {
+  Node *const expected = List({
+    // Nested tuple in for-loop variables
+    ListComprehension(
+      List::Type::kList,
+      For(Op('+', Id("a"), Id("b")),
+          In(Tuple({Id("a"), Tuple({Id("b"), Id("c")})}),
+             Id("LIST_WITH_TUPLES")))),
+  });
+
+  EXPECT_EQ(Print(expected), Print(Parse(R"(
+  [a + b for a, (b, c) in LIST_WITH_TUPLES]
+)")));
+}
+
+TEST_F(ParserTest, ParseListComprehensionDeeplyNestedTuple) {
+  Node *const expected = List({
+    // Deeply nested tuple in for-loop variables
+    ListComprehension(
+      List::Type::kList,
+      For(Op('+', Id("a"), Id("e")),
+          In(Tuple({Tuple({Id("a"), Tuple({Id("b"), Id("c")})}),
+                    Tuple({Id("d"), Id("e")})}),
+             Id("DEEPLY_NESTED_TUPLES")))),
+  });
+
+  EXPECT_EQ(Print(expected), Print(Parse(R"(
+  [a + e for (a, (b, c)), (d, e) in DEEPLY_NESTED_TUPLES]
+)")));
+}
+
 TEST_F(ParserTest, ParseListComprehensionIf) {
   Node *const expected = List({
     // Simple filter

--- a/bant/frontend/parser_test.cc
+++ b/bant/frontend/parser_test.cc
@@ -480,11 +480,10 @@ TEST_F(ParserTest, ParseListComprehension) {
 TEST_F(ParserTest, ParseListComprehensionTuple) {
   Node *const expected = List({
     // Nested tuple in for-loop variables
-    ListComprehension(
-      List::Type::kList,
-      For(Op('+', Id("a"), Id("b")),
-          In(Tuple({Id("a"), Tuple({Id("b"), Id("c")})}),
-             Id("LIST_WITH_TUPLES")))),
+    ListComprehension(List::Type::kList,
+                      For(Op('+', Id("a"), Id("b")),
+                          In(Tuple({Id("a"), Tuple({Id("b"), Id("c")})}),
+                             Id("LIST_WITH_TUPLES")))),
   });
 
   EXPECT_EQ(Print(expected), Print(Parse(R"(
@@ -495,12 +494,11 @@ TEST_F(ParserTest, ParseListComprehensionTuple) {
 TEST_F(ParserTest, ParseListComprehensionDeeplyNestedTuple) {
   Node *const expected = List({
     // Deeply nested tuple in for-loop variables
-    ListComprehension(
-      List::Type::kList,
-      For(Op('+', Id("a"), Id("e")),
-          In(Tuple({Tuple({Id("a"), Tuple({Id("b"), Id("c")})}),
-                    Tuple({Id("d"), Id("e")})}),
-             Id("DEEPLY_NESTED_TUPLES")))),
+    ListComprehension(List::Type::kList,
+                      For(Op('+', Id("a"), Id("e")),
+                          In(Tuple({Tuple({Id("a"), Tuple({Id("b"), Id("c")})}),
+                                    Tuple({Id("d"), Id("e")})}),
+                             Id("DEEPLY_NESTED_TUPLES")))),
   });
 
   EXPECT_EQ(Print(expected), Print(Parse(R"(


### PR DESCRIPTION
Refine the parsing of the for-loop to allow elements to be destructured `for a, (b, c)`