### PR TITLE
Attempt to compile on Windows...

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,29 +9,36 @@ build --features=layering_check
 build --features=parse_headers
 
 # C++, with warnings mostly turned to 11.
-build       --cxxopt=-std=c++20            --host_cxxopt=-std=c++20
-build       --cxxopt=-xc++                 --host_cxxopt=-xc++
-build       --cxxopt=-Wall                 --host_cxxopt=-Wall
-build       --cxxopt=-Wextra               --host_cxxopt=-Wextra
-build       --cxxopt=-Wno-unused-parameter --host_cxxopt=-Wno-unused-parameter
+# the following options work well on unix-style compilers gcc and clang
+build:unix  --cxxopt=-std=c++20            --host_cxxopt=-std=c++20
+build:unix  --cxxopt=-xc++                 --host_cxxopt=-xc++
+build:unix  --cxxopt=-Wall                 --host_cxxopt=-Wall
+build:unix  --cxxopt=-Wextra               --host_cxxopt=-Wextra
+build:unix  --cxxopt=-Wno-unused-parameter --host_cxxopt=-Wno-unused-parameter
 
 # Avoid costly language features.
-build       --cxxopt=-fno-exceptions       --host_cxxopt=-fno-exceptions
-build       --cxxopt=-fno-rtti             --host_cxxopt=-fno-rtti
+build:unix  --cxxopt=-fno-exceptions       --host_cxxopt=-fno-exceptions
+build:unix  --cxxopt=-fno-rtti             --host_cxxopt=-fno-rtti
 
-# Bazel compiles headers and then compiler complains about -c arg.
-build --copt=-Wno-unused-command-line-argument
+# Platform specific options.
+build --enable_platform_specific_config
+
+common:linux   --config=unix
+common:freebsd --config=unix
+common:openbsd --config=unix
+common:macos   --config=unix
+
+build:macos --macos_minimum_os=10.15
+build:macos --features=-supports_dynamic_linker
+build:macos --cxxopt=-std=c++2b            --host_cxxopt=-std=c++2b
+
+# Flags on windows are different
+build:windows  --cxxopt=/std:c++20  --host_cxxopt=/std:c++20 --client_env=BAZEL_CXXOPTS=/std:c++20
 
 # For 3rd party code: Disable warnings entirely.
 # They are not actionable and just create noise.
 build --per_file_copt=external/.*@-w
 build --host_per_file_copt=external/.*@-w
-
-# Platform specific options.
-build --enable_platform_specific_config
-build:macos --macos_minimum_os=10.15
-build:macos --features=-supports_dynamic_linker
-build:macos --cxxopt=-std=c++2b            --host_cxxopt=-std=c++2b
 
 # Print out test log on failure.
 test --test_output=errors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,27 @@ jobs:
           bazel-bin/bant/bant -V  # Print version
           # TODO: package ?
 
+  WindowsBuild:
+    runs-on: windows-latest
+    steps:
+      - name: Check out with linefeed
+        run: git config --global core.autocrlf false
+
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Test
+        run: |
+          bazel test --noshow_progress --keep_going --test_output=errors ...
+
+      - name: Build
+        run: |
+          bazel build --noshow_progress -c opt bant:bant
+          bazel-bin/bant/bant -V  # Print version
+          # TODO: package ?
+
   CodeFormatting:
     runs-on: ubuntu-latest
     steps:

--- a/bant/util/arena-container_test.cc
+++ b/bant/util/arena-container_test.cc
@@ -17,11 +17,23 @@
 
 #include "bant/util/arena-container.h"
 
+#include <cstddef>
+#include <cstdint>
+
 #include "bant/util/arena.h"
 #include "gtest/gtest.h"
 
 namespace bant {
 namespace {
+TEST(Arena, Alignment) {
+  Arena a(1024);
+  for (size_t size = 1; size <= 256; ++size) {
+    void *p = a.Alloc(size);
+    EXPECT_NE(p, nullptr);
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(p) % 8, 0u);
+  }
+}
+
 TEST(ArenaDeque, SimpleOps) {
   Arena a(1024);
   ArenaDeque<int, 3, 96> container;  // deliberately funky min..max

--- a/bant/util/arena.h
+++ b/bant/util/arena.h
@@ -71,7 +71,7 @@ class Arena {
 
   ~Arena() {
     for (void *p : blocks_) {
-      std::free(p);
+      LowLevelFree(p);
     }
 
     if (!verbose_ || blocks_.empty()) return;
@@ -88,8 +88,20 @@ class Arena {
   void SetVerbose(bool verbose) { verbose_ = verbose; }
 
  private:
+  static void LowLevelFree(void *p) {
+#ifdef _WIN32
+    _aligned_free(p);
+#else
+    std::free(p);
+#endif
+  }
+
   void *LowLevelAlloc(size_t size) {
+#ifdef _WIN32
+    return blocks_.emplace_back(_aligned_malloc(size, kAlignment));
+#else
     return blocks_.emplace_back(std::aligned_alloc(kAlignment, size));
+#endif
   }
 
   void *NextBlockAlloc(size_t size) {

--- a/bant/util/file-utils.cc
+++ b/bant/util/file-utils.cc
@@ -114,6 +114,11 @@ bool FilesystemPath::is_symlink() const {
 
 // Just in a struct, so that FilesystemPath can be 'friends' :)
 // The update_known_is_directory() method should not really be visible.
+#if defined __WIN32__ || defined _WIN32 || defined _Windows
+#if !defined S_ISDIR
+#define S_ISDIR(m) (((m) & _S_IFDIR) == _S_IFDIR)
+#endif
+#endif
 struct InternalDirectoryStat {
   // Test if symbolic link points to a directory and return 'true' if it does.
   // Update "out_inode" with the inode at the destination.

--- a/bant/util/table-printer.cc
+++ b/bant/util/table-printer.cc
@@ -17,7 +17,14 @@
 
 #include "bant/util/table-printer.h"
 
-#include <unistd.h>
+#ifndef _WIN32
+#include <unistd.h>  // for isatty
+#else
+#include <io.h>
+// MSVC recommends to use _isatty...
+#define isatty        _isatty
+#define STDOUT_FILENO 1
+#endif
 
 #include <algorithm>
 #include <cstddef>


### PR DESCRIPTION
Just a test to see what needs to be done to make this compile on Windows. It is hard to debug without access to a windows machine, so left here in case someone wants to dig into it.

  * [x] filesystem operations would need to be ported (they are typically in filesystem.cc, so it might be doable by wrapping `std::filesystem`) (done)
  *  [ ] there is no `getopt()`. Hopefully not too big of a deal as the command line handling needs to be re-done anyway, and it might not be an issue anymore 
  * [ ] Some tests don't seem to work at all, e.g. the parser test. The scanner tests work, so the sequence of tokens should be fine, yet the parser fails. Needs a Windows machine to figure out.
  * [ ]  There might also be some implicit assumptions of how line endings look like.